### PR TITLE
RSESPRT-326: Fix Bulk Deletion Of Tags

### DIFF
--- a/civicrm_entity.info
+++ b/civicrm_entity.info
@@ -10,3 +10,7 @@ files[] = civicrm_entity_ui_controller.inc
 files[] = civicrm_entity_metadata_controller.inc
 files[] = civicrm_entity_default_views_controller.inc
 
+version = 7.x-2.4-patch1
+; patch 1
+
+

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -3585,15 +3585,25 @@ function civicrm_entity_civicrm_post($op, $object_name, $object_id, &$object_ref
   if ($entity_name == 'entity_tag') {
     // Argh entity tag is completely non-standard!!!
     // @see CRM-11933
-    foreach ($object_ref[0] as $entity_tag) {
-      $object = new CRM_Core_BAO_EntityTag();
-      $object->entity_id = $entity_tag;
+    if ($object_ref instanceof CRM_Core_DAO_EntityTag) {
+      $object               = new CRM_Core_BAO_EntityTag();
+      $object->entity_id    = $object_ref->entity_id;
       $object->entity_table = 'civicrm_contact';
-      $object->tag_id = $object_id;
+      $object->tag_id       = $object_ref->tag_id;
       if ($object->find(TRUE)) {
-        // This find is probably not necessary but until more testing
-        // on the tag create is done I will.
         rules_invoke_event($event_name, $object);
+      }
+    } elseif (!empty($object_ref[0]) && is_array($object_ref[0])) {
+      foreach ($object_ref[0] as $entity_tag) {
+        $object               = new CRM_Core_BAO_EntityTag();
+        $object->entity_id    = $entity_tag;
+        $object->entity_table = 'civicrm_contact';
+        $object->tag_id       = $object_id;
+        if ($object->find(TRUE)) {
+          // This find is probably not necessary but until more testing
+          // on the tag create is done I will.
+          rules_invoke_event($event_name, $object);
+        }
       }
     }
   }


### PR DESCRIPTION
## Overview
This pr fixes the bulk deletion of tags for different civicrm entities.

## Before
<img width="1674" alt="Screenshot 2024-11-26 at 9 43 44 AM" src="https://github.com/user-attachments/assets/ad25ea0b-bd4d-48b3-8f01-46fc32d5d5db" />

## After
![screen_recording_after](https://github.com/user-attachments/assets/b523e168-e28d-42d8-9396-07840bd9f88a)

## Technical Details
This pr fixes a bug which was happening due to the fact that this module was assuming that on a post hook we always receives an array but for deletion civicrm fires the post hook with an object as explained [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/DAO.php#L1125)