### PR TITLE
RSESPRT-270: Fetch entity fields in batches

### DIFF
--- a/civicrm_entity_controller.inc
+++ b/civicrm_entity_controller.inc
@@ -327,8 +327,24 @@ class CivicrmEntityController extends EntityAPIController {
 
     // get what we get by the 'return' property in the API call
     if(!empty($return_fields['return'])) {
-      $condition['return'] = $return_fields['return'];
-      $civicrm_entities2 = civicrm_api3($this->entityInfo['description'], 'get', $condition);
+      $batch_size = 50; // Maximum fields per request to avoid too many joins
+      $return_batches = array_chunk($return_fields['return'], $batch_size);
+      
+      $civicrm_entities2 = ['values' => []];
+      foreach ($return_batches as $return_batch) {
+        $batch_condition = $condition;
+        $batch_condition['return'] = $return_batch;
+        
+        $batch_result = civicrm_api3($this->entityInfo['description'], 'get', $batch_condition);
+        
+        // Merge batch results
+        foreach ($batch_result['values'] as $id => $entity) {
+          if (empty($civicrm_entities2['values'][$id])) {
+            $civicrm_entities2['values'][$id] = [];
+          }
+          $civicrm_entities2['values'][$id] = array_merge($civicrm_entities2['values'][$id], $entity);
+        }
+      }
     }
 
     // merge the two together


### PR DESCRIPTION
## Overview
This PR resolved the issue with the Civi User not being able to delete any cases/awards application

![image](https://github.com/user-attachments/assets/d6c3840b-2dcd-4886-87c4-5d444fb73329)

The issue occurs because CiviCRM implicitly enforces a limit on the number of custom fields an entity can have. This limitation, around 60 custom fields, is due to MySQL's restriction of a maximum of 61 table joins in a single SELECT statement. More details on this limitation can be found in the MySQL documentation: [MySQL Join Limit](https://dev.mysql.com/doc/refman/8.4/en/join.html#:~:text=The%20maximum%20number%20of%20tables,a%20single%20join%20is%2061).

In most cases, users will not encounter this issue unless they execute an API query that attempts to retrieve an entity along with all its custom fields. More discussions on this can be found in the CiviCRM issue tracker: [CiviCRM Core Issue #1191](https://lab.civicrm.org/dev/core/-/issues/1191).

Impact on Entity (Case in this situation) Deletion

When attempting to delete an entity, the civicrm_entity module triggers a hook that executes a method within the controller: https://github.com/eileenmcnaughton/civicrm_entity/blob/7.x-2.x/civicrm_entity_controller.inc#L329-L332 . This method retrieves all fields associated with the entity being deleted, causing the query to exceed MySQL’s join limit and resulting in an error.

To resolve this issue, We modify the hook behaviour to prevent it from fetching all fields at once and instead fetching in batches, thereby avoiding the MySQL join limit error.

