### PR TITLE
CSTMM-148: Add error reset to fix the user creation with same first and last name

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -3070,6 +3070,8 @@ function civicrm_entity_action_create_user($contact, $is_active, $notify = FALSE
          watchdog('civicrm_entity', 'Check name %error.', array('%error' => $error), WATCHDOG_ERROR);
        }
        $params['name'] = $params['name'] . "$ind";
+       // Reset the errors when we check new username.
+       $errors = array();
     }
     else {
        $ind = 0;


### PR DESCRIPTION
## Overview
This PR resolves the issue of user creation not happening when there are same first name and last name. 
When we upgraded the civicrm from 5.51 to 5.75 the underlying Drupal.php function named `checkUserNameEmailExists` which is responsible to check for user existence and return errors got changed and the reset was changed to merge the drupal errors which should be reset. This resulted in stopping the user creation with same first name and last.  

We fixed the error reset variable in the drupal modules using that function so that the users will be created with same first name and last name. 

## Drupal.php In cvicrm version 5.51
<img width="686" height="141" alt="image" src="https://github.com/user-attachments/assets/a430aa53-60c9-4807-9e2f-143788d2c011" />

## Drupal.php In cvicrm version 5.75
<img width="678" height="111" alt="image" src="https://github.com/user-attachments/assets/1560201a-e80b-49f4-b524-ae9e5c5e4978" />



## Before
<img width="1814" height="667" alt="Screenshot 2025-10-01 at 11 59 59 AM" src="https://github.com/user-attachments/assets/4bdd71d2-e85d-48ec-8314-c99fd882ffdb" />


## After

<img width="1864" height="828" alt="Screenshot 2025-10-01 at 12 02 22 PM" src="https://github.com/user-attachments/assets/52887355-8325-4630-839d-739e0873ad03" />


